### PR TITLE
Recheck element listener existence before callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,9 @@ function handleScroll () {
 }
 
 function runCallbacks (elem) {
+  if (!elem || !elem.__resize_listeners__) {
+    return
+  }
   elem.__resize_listeners__.forEach(callback => {
     callback.call(elem)
   })


### PR DESCRIPTION
Recheck element and element listeners existence before running callbacks (Fixes #6)