### PR TITLE
Cope with null document

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -62,7 +62,7 @@ export function getComputedStyle (elem, prop, pseudo) {
 }
 
 export function getRenderInfo (elem) {
-  if (!document.documentElement.contains(elem)) {
+  if (!document || !document.documentElement.contains(elem)) {
     return {
       detached: true,
       rendered: false


### PR DESCRIPTION
This can happen in unit tests, especially when using Jest with jsdom.

You may get warnings like:

```
    Cannot log after tests are done. Did you forget to wait for something async in your test?
        Attempted to log "Error: Uncaught [TypeError: Cannot read property 'documentElement' of null]
```

If we check for the existence of the document first, we can tidy up our test output.